### PR TITLE
Only include functions with lines considered on the report

### DIFF
--- a/go_coverage.go
+++ b/go_coverage.go
@@ -171,14 +171,16 @@ func getFunctionInfos(profiles []*cover.Profile) ([]*funcInfo, int64, int64, err
 		// Now match up functions and profile blocks.
 		for _, f := range funcs {
 			c, t := f.coverage(profile)
-			funcInfos = append(funcInfos,
-				&funcInfo{fileName: file,
-					functionName:      f.name,
-					functionStartLine: f.startLine,
-					functionEndLine:   f.endLine,
-					uncoveredLines:    t - c})
-			total += t
-			covered += c
+			if t != 0 {
+				funcInfos = append(funcInfos,
+					&funcInfo{fileName: file,
+						functionName:      f.name,
+						functionStartLine: f.startLine,
+						functionEndLine:   f.endLine,
+						uncoveredLines:    t - c})
+				total += t
+				covered += c
+			}
 		}
 	}
 	return funcInfos, total, covered, nil
@@ -270,9 +272,7 @@ func (f *FuncExtent) coverage(profile *cover.Profile) (num, den int64) {
 			covered += int64(b.NumStmt)
 		}
 	}
-	if total == 0 {
-		total = 1 // Avoid zero denominator.
-	}
+
 	return covered, total
 }
 


### PR DESCRIPTION
This change avoids to add functions that have no lines on the coverage report, needed for reports filtered by line, as in a PR changes coverage report.

Currently it is reporting 1 line missing coverage of every function not present on the report.
This could be seen for example with this report, which was filtered to only the first two blocks of code:
```
mode: atomic
github.com/gojek/go-coverage/go_coverage.go:22.13,58.38 2 0
github.com/gojek/go-coverage/go_coverage.go:99.2,100.16 2 0
```
Currently it returns:
```
+-------------------------+--------------------+-----------------+--------+
|          FILE           |      FUNCTION      | UNCOVERED LINES | IMPACT |
+-------------------------+--------------------+-----------------+--------+
| ...erage/go_coverage.go | main               |               4 |   26.7 |
| ...erage/go_coverage.go | getTrimmedFileName |               1 |    6.7 |
| ...erage/go_coverage.go | fmtFuncInfo        |               1 |    6.7 |
| ...erage/go_coverage.go | printBat           |               1 |    6.7 |
| ...erage/go_coverage.go | calculateCoverage  |               1 |    6.7 |
| ...erage/go_coverage.go | printTable         |               1 |    6.7 |
| ...erage/go_coverage.go | getFunctionInfos   |               1 |    6.7 |
| ...erage/go_coverage.go | trimString         |               1 |    6.7 |
| ...erage/go_coverage.go | findFuncs          |               1 |    6.7 |
| ...erage/go_coverage.go | Visit              |               1 |    6.7 |
| ...erage/go_coverage.go | coverage           |               1 |    6.7 |
| ...erage/go_coverage.go | findFile           |               1 |    6.7 |
+-------------------------+--------------------+-----------------+--------+
```
With this changes will return only the functions present on the report :
```
+-------------------------+----------+-----------------+--------+
|          FILE           | FUNCTION | UNCOVERED LINES | IMPACT |
+-------------------------+----------+-----------------+--------+
| ...erage/go_coverage.go | main     |               4 |  100.0 |
+-------------------------+----------+-----------------+--------+
```